### PR TITLE
feat: add confirmation dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,16 +14,16 @@ This adds a right click entry in Dolphin to remove all metadata / EXIF data from
 
 ### Prerequisites
 
-Requires [ExifTool](https://exiftool.org/) to be installed, for example:  
+Requires [ExifTool](https://exiftool.org/) and kdialog to be installed, for example:  
 
 **Fedora**
-- `sudo dnf install perl-Image-ExifTool`
+- `sudo dnf install perl-Image-ExifTool kdialog`
 
 **Ubuntu**
-- `sudo apt install libimage-exiftool-perl`  
+- `sudo apt install libimage-exiftool-perl kdialog`  
 
 **Arch / Manjaro**
-- `sudo pacman -S perl-image-exiftool`  
+- `sudo pacman -S perl-image-exiftool kdialog`  
 
 ### Automatic Install
 

--- a/removeMetadata.desktop
+++ b/removeMetadata.desktop
@@ -12,4 +12,4 @@
  Name[pl]=Usuń Metadane
  Name[zh_TW]=移除後設資料
  Icon=document-cleanup
- Exec=exiftool -all= %U -tagsfromfile @ -Orientation -overwrite_original
+ Exec=kdialog --yesno 'Exif metadata is going to removed. Are you sure?' --title 'Confirmation' && exiftool -all= %U -tagsfromfile @ -Orientation -overwrite_original


### PR DESCRIPTION
This patch adds confirmation dialog. kdialog needs to be added as a dependency. Maybe it comes normally with KDE/Plasma desktop? Should close issue #8.